### PR TITLE
ENH: Base documentation for the Community of NiPreps

### DIFF
--- a/docs/community/CODE_OF_CONDUCT.md
+++ b/docs/community/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# *NiPreps* Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting Oscar Esteban at <oesteban@stanford.edu>
+or Chris Markiewicz at <markiewicz@stanford.edu>, two members of the project team.
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/docs/community/CONTRIBUTING.md
+++ b/docs/community/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+# Contributing Guidelines
 
 Welcome to the *NiPreps* project!
 We're excited you're here and want to contribute.
@@ -299,37 +300,11 @@ These special positions can be revised to add names by punctual request and revi
 removal and update of ordering in an scheduled manner every two years.
 All the authors enlisted as *creators* participate in the revision of modifications.
 
-### Developers
-
-Developers are members of a wonderful team _driving the project_.
-Names and contacts of all developers are included in the
-[``.maint/developers.json`` file](https://github.com/poldracklab/fmriprep/blob/master/.maint/developers.json)
-Examples of steering activities that _drive the project_ are: actively participating in the
-follow-up meetings, leading documentation sprints, helping in the design of the tool and definition of the roadmap,
-providing resources (in the broad sense, including funding), code-review, etc.
-
-### Contributors
-
-Contributors enlisted in the
-[``.maint/contributors.json`` file](https://github.com/poldracklab/fmriprep/blob/master/.maint/contributors.json)
-actively help or have previously helped the project in a broad sense: writing code, writing documentation,
-benchmarking modules of the tool, proposing new features, helping improve the scientific
-rigor of implementations, giving out support on the different communication
-channels ([mattermost][link_mattermost], [NeuroStars][link_neurostars], [GitHub issues][link_issues], etc.).
-If you are new to the project, don't forget to add your name and affiliation to the list
-of contributors there!
-Our Welcome Bot will send an automated message reminding this to first-time contributors.
-Before every release, unlisted contributors will be invited again to add their names to the file
-(just in case they missed the automated message from our Welcome Bot).
-
-Contributors who have contributed at some point to the project but were required or they wished to
-disconnect from the project's updates and to drop-out from publications and other dissemination activities,
-are listed in the [``.maint/former.json`` file](https://github.com/poldracklab/fmriprep/blob/master/.maint/former.json).
-
 ### Publications
 
 Anyone listed as a *developer* or a *contributor* can start the submission process of a manuscript
-as first author.
+as first author (please see [Membership](members.md), where these concepts are
+described).
 To compose the author list, all the *creators* MUST be included (except for those people who
 opt to drop-out) and all the *contributors* MUST be invited to participate.
 First authorship(s) is (are) reserved for the authors that originated and kept the initiative

--- a/docs/community/features.md
+++ b/docs/community/features.md
@@ -1,0 +1,116 @@
+
+> The one bit that worries me is that *fMRIPrep* may become a Swiss army knife. I think instead it should just be a paring knife (small, efficient, and works for many things).
+>
+> -- <cite>Satra ([source](https://github.com/poldracklab/fmriprep/issues/1963#issuecomment-584455061))</cite>
+
+When projects grow large, many forking paths created by newly implemented features start
+to open up.
+To account for this, the *NiPreps* community was created with the vision of building
+tools like *fMRIPrep* and *MRIQC* covering new imaging modalities, while keeping
+existing *NiPreps* tightly within scope.
+Defining such a scope also aids the implementation of the ease-of-use principle:
+
+> The same way the scanner does not offer an immense space of knobs to turn
+> in the acquisition, *NiPreps* should not add many additional knobs to those
+> for them to be considered a viable *augmentation* or extension of the scanner hw/sw.
+>
+> -- <cite>Oscar ([source](https://github.com/poldracklab/fmriprep/issues/1963#issuecomment-584455061))</cite>
+
+## The problem of feature creep
+To avert [feature creep](https://en.wikipedia.org/wiki/Feature_creep) and
+to serve each individual *NiPrep*, we developed the following
+guidelines, with the hopes of keeping these tools in a healthy state.
+
+> I'm worried *fMRIPrep* is catching a case of featuritis
+>
+> -- <cite>Mathias ([source](https://github.com/poldracklab/fmriprep/issues/1985#issuecomment-588493059))</cite>
+
+These guidelines should also serve the community to transparently drive the process
+of including proposals into the road-map, set the ground for healthy conversation,
+and establish some patterns when accepting new-feature contributions.
+Before proposing new features, please be mindful that a road-map may not exist
+for a particular *NiPrep*.
+Even when a development road-map exists, please understand that it is not always
+possible to rigorously follow them:
+
+> I think something like this is what we tried to start sketching out with
+> the development roadmap. The concern, as I remember it, was that we couldn't
+> guarantee (or rule out) specific features when working with a small
+> development team.
+>
+> -- <cite>Elizabeth ([source](https://github.com/poldracklab/fmriprep/issues/1963#issuecomment-582453941))</cite>.
+
+## Proposing a new feature
+
+### Why the new feature is requested?
+Before going ahead and proposing a new feature, please take some time to
+learn whether the topic has been covered in the past and what decisions
+were made and why.
+This should be reasonably easy to do with the search tool of GitHub on the
+particular *NiPrep* repository.
+
+If no previous discussion about the new idea is found,
+the next step is ensuring the new feature aligns with the vision and
+the scope of the target tool, as
+[Elizabeth points out](https://github.com/poldracklab/fmriprep/issues/1963#issuecomment-582453941).
+Taking a look into the Development Road-map of the particular project
+(if it exists), may help finding an answer.
+
+If the new feature still seems pertinent after this preliminary work
+or you are unsure about whether it falls within the scope, then
+go ahead and post an issue requesting feedback on your proposal.
+Please make sure to clearly state why the new feature should be considered.
+
+### Some questions will always be asked about a new feature
+[These questions by James](https://github.com/poldracklab/fmriprep/issues/1963#issuecomment-582220173)
+will certainly help build up the discourse in support of the new feature,
+as the *NiPreps* maintainers will consider them:
+
+  * **Is the user interface affected?**
+    Because *NiPreps* generally expose a *command-line interface (CLI)* for the
+    interaction with the user, new features involving changes to the CLI must be
+    considered with caution as they may harm the ease-of-use:
+
+    > It also seems that some new features add more confusion than others.
+    > Especially when the CLI is affected, and yet another option is added,
+    > that makes the tool more complex to use.
+    >
+    > -- <cite>Alejandro ([source](https://github.com/poldracklab/fmriprep/    issues/1963#issuecomment-582174814))</cite>.
+
+  * Does the new feature substantially **increase the internal complexity**?
+    Maintainers and developers will attempt to consolidate tools and lower the internal
+    complexity whenever possible.
+    This effort usually competes with the addition of new features as they typically will
+    address particular use-cases rather than general improvements.
+    However, that doesn't need to be the case, as some sections of the code might be
+    objectively improvable and the integration of a new feature revising those might
+    also lower complexity.
+    Lowering the internal complexity will always be considered a great incentive
+    for a new feature to be accepted.
+
+  * Is there **a standard procedure** for the proposed feature in the literature?
+
+      * if so, could we just use that procedure/value?
+
+  * Is the **feature dependent** on some attribute of the input data? (e.g., TR, duration, etc.)
+
+      * if so, can the procedure/value be determined algorithmically?
+
+  * Does the feature **interact with other settings**?
+    For instance, [fmriprep#1962](https://github.com/poldracklab/fmriprep/pull/1962)
+    interacts with the a/tCompCor implementation.
+
+  * What is the **difficulty of implementing the procedure outside** of a *NiPrep*?
+    In other words, does the *NiPrep* provide all the necessary outputs for a
+    user to perform the non-standard analysis?
+
+
+
+### How the integration of the new feature will/can be validated?
+
+Please propose ways to validate the new feature in the context of
+the workflow. Meaning, the objective here is to validate that the new
+feature works well within the pipeline, rather than validating a specific
+algorithm.
+To ensure the sustainability of *NiPreps*, the onus of this validation
+should be on the person/group requesting the feature.

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -1,0 +1,40 @@
+# Join the *NiPreps* Community
+
+One of the pillars of *fMRIPrep*, the seed project for *NiPreps*,
+has been nurturing an open-source community.
+[Building Welcoming Communities](https://opensource.guide/building-community/)
+is crucial for open-source software because of several reasons:
+
+  * Engaging users and *contributors* (in a very liberal sense, not just with code)
+    helps establish a development road-map:
+
+      * In the case of *fMRIPrep*, many users have reported bugs via our issue
+        tracker and [Neurostars.org].
+        Even though testing is one of the primary focuses for *fMRIPrep*, without these
+        bug-report contributions the tool would have never reached the dependability level
+        it requires to serve its purpose.
+      * Users identify and propose new features, often illuminating shady areas the
+        most involved developers did not find time or the right context to explore.
+
+  * The community exposes the software and also increases the externality of the software.
+    The neuroimaging discussion supported by [Neurostars.org]
+    has been a key factor for the adoption of *fMRIPrep*.
+
+  * Users always give back, and it is not uncommon to see elaborate responses
+    to bug-reports and questions about *fMRIPrep* on [Neurostars.org]
+    by users who had similar questions previously.
+
+Because of the scientific purpose of *NiPreps*, there is one more **fundamental**
+reason to grow a (scientific) community around the tools: **rigor/scrutiny**.
+As one reviews a few of the most discussed pull-requests to *fMRIPrep*, very soon
+they realize that we don't just need to get the code right.
+We strive for integrating high-quality code, but even more importantly, that code
+must get the scientific method it implements right.
+This is particularly difficult because in most of the cases there aren't
+test oracles (in software engineering terms) or gold-standards (in scientific terms)
+to efficiently evaluate the validity of new features (even to exercise a minuscule area
+of the domain of inputs).
+The redundancy of expert eyes looking at our code has only helped make it better.
+
+[Neurostars.org]: https://neurostars.org
+

--- a/docs/community/members.md
+++ b/docs/community/members.md
@@ -1,0 +1,35 @@
+In general, *NiPreps* embrace a [*liberal contribution model*](https://opensource.guide/leadership-and-governance/#what-are-some-of-the-common-governance-structures-for-open-source-projects)
+of governance structure.
+However, because of the scientific domain of *NiPreps*, the community features some
+structure from *meritocracy models* to prescribe the order in the
+authors list of [new papers about these tools](CONTRIBUTING.md#publications).
+
+## Developers
+
+Developers are members of a wonderful team _driving the project_.
+Names and contacts of all developers are included in the
+[`.maint/developers.json` file](https://github.com/poldracklab/fmriprep/blob/master/.maint/developers.json) of each project.
+Examples of steering activities that _drive the project_ are: actively participating in the
+follow-up meetings, leading documentation sprints, helping in the design of the tool and definition of the roadmap,
+providing resources (in the broad sense, including funding), code-review, etc.
+
+## Contributors
+
+Contributors enlisted in the
+[`.maint/contributors.json` file](https://github.com/poldracklab/fmriprep/blob/master/.maint/contributors.json) of each project
+actively help or have previously helped the project in a broad sense: writing code, writing documentation,
+benchmarking modules of the tool, proposing new features, helping improve the scientific
+rigor of implementations, giving out support on the different communication
+channels (mattermost, [NeuroStars][link_neurostars], GitHub, etc.).
+If you are new to the project, don't forget to add your name and affiliation to the list
+of contributors there!
+Our Welcome Bot will send an automated message reminding this to first-time contributors.
+Before every release, unlisted contributors will be invited again to add their names to the file
+(just in case they missed the automated message from our Welcome Bot).
+
+Contributors who have contributed at some point to the project but were required or they wished to
+disconnect from the project's updates and to drop-out from publications and other dissemination activities,
+are listed in the [`.maint/former.json` file](https://github.com/poldracklab/fmriprep/blob/master/.maint/former.json).
+
+
+[link_neurostars]: https://neurostars.org

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,8 +18,13 @@ nav:
       - Introduction: apps/framework.md
       - Executing with Docker: apps/docker.md
       - Executing with Singularity: apps/singularity.md
+    - Community:
+      - Welcome: community/index.md
+      - Membership: community/members.md
+      - New features: community/features.md
+      - Contributing: community/CONTRIBUTING.md
+      - Code of Conduct: community/CODE_OF_CONDUCT.md
     - Developers:
-      - Contributing Guidelines: devs/guidelines.md
       - Versions Matrix: devs/versions.md
       - Releases: devs/releases.md
 theme:


### PR DESCRIPTION
This PR provides a base structure for the website and moves some documentation from *fMRIPrep*. The endgoal is to unify the community aspects and contribution guidelines across the NiPreps framework.

This PR is a first step to implement poldracklab/fmriprep#1963 to prescribe how new features (and requests) will be considered, processed, and evaluated. After this first stab, the idea is to continue with more concrete points of poldracklab/fmriprep#1963 not covered here.

cc/ @nipreps/enthusiasts @nipreps/developers @nipreps/dmriprep 