### PR TITLE
ENH:add two news

### DIFF
--- a/docs/news/index.md
+++ b/docs/news/index.md
@@ -7,5 +7,21 @@ permalink: /news.html
 ---
 
 # News and Announcements
+## NiPreps ISMRM 2023 Satellite Hackathon 
+
+Registration for the NiPreps / ISMRM 2023 Satellite Hackathon is now open!
+
+To register, please fill out the Google Form provided at the following link:
+ISMRM 2023 Hackathon Registration: [Registration](https://docs.google.com/forms/d/e/1FAIpQLSf6dD1iLfRV4xKx6yfvXN1JsHyajFzU90w15Rq0p_X2qhcH5A/viewform?usp=sf_link)
+
+Please note that registration is required to participate in the hackathon, and space is limited, so we encourage you to register early to secure your spot.
+The hackathon will take place on the day after the conference in Toronto at the Krembil Centre for Neuroinformatics. Participants will have the chance to collaborate with experts in the field, learn new skills, and work on innovative solutions to data analysis challenges.
+
+Stay tuned for more information about the hackathon, including specific topics to be addressed and any additional materials you may need to bring with you.
+We look forward to seeing you all at ISMRM 2023 and at the hackathon the following day!
+
+## NiPreps Roundups <span style="color: grey; font-size: 72%; position: relative; right: -10px;"> Feb 22, 2023</span>
+
+We resumed the bi-monthly NiPreps Roundups with a first meeting on February 22, 2023.
 
 


### PR DESCRIPTION
-  Add news about ISMRM 2023 Satellite Hackathon and NiPreps Roundup.
-  Permalinks are enabled in news section #26 .