### PR TITLE
DOC: Add Apptainer warning to Singularity docs

### DIFF
--- a/docs/apps/singularity.md
+++ b/docs/apps/singularity.md
@@ -4,7 +4,8 @@
     To illustrate the process, we will show the execution of *fMRIPrep*, but these guidelines extend to any other end-user *NiPrep*.
 
 !!! warning "Apptainer"
-    In 2021, Singularity was migrated and became Apptainer. Despite this, all below commands that contain `singularity` will execute Apptainer, and can be replaced with the `apptainer` command with no change in function. 
+    In 2021, [*Singularity* was rebranded as *Apptainer* when the project was transferred to the Linux Foundation](https://apptainer.org/news/community-announcement-20211130/).
+    As noted in the community announcement, all the commands below that contain `singularity` as the command line executable will execute *Apptainer* and can be replaced with the `apptainer` command with no change in function. 
 
 ## Preparing a Singularity image
 

--- a/docs/apps/singularity.md
+++ b/docs/apps/singularity.md
@@ -3,6 +3,9 @@
     Here, we describe how to run *NiPreps* with Singularity containers.
     To illustrate the process, we will show the execution of *fMRIPrep*, but these guidelines extend to any other end-user *NiPrep*.
 
+!!! warning "Apptainer"
+    In 2021, Singularity was migrated and became Apptainer. Despite this, all below commands that contain `singularity` will execute Apptainer, and can be replaced with the `apptainer` command with no change in function. 
+
 ## Preparing a Singularity image
 
 **Singularity version >= 2.5**:


### PR DESCRIPTION
There was a brief discussion at one of the monthly roundup meetings about Singularity vs. Apptainer. In our MRIQC protocol paper, we refer to it as Apptainer and link out to this documentation, so at minimum, I think we need to flag that anywhere in this documentation where you use `singularity`, you can substitute `apptainer`. @jhlegarreta mentioned that the reality of the situation is not so straightforward as "Singularity was renamed to Apptainer", but that does seem to be the most succinct way to explain it without getting into the behind the scenes business details. 

@oesteban 