### PR TITLE
STY: Accept three-letter prefix for maintenance commits

### DIFF
--- a/docs/community/CONTRIBUTING.md
+++ b/docs/community/CONTRIBUTING.md
@@ -220,6 +220,9 @@ but those accepted fastest will follow a workflow similar to the following:
   using a [NiPreps development environment][link_devel].
   Once you are satisfied with your local changes, [add/commit/push them][link_add_commit_push]
   to the branch on your forked repository.
+  Note that that each commit must include changes that serve a coherent
+  purpose only (e.g. documentation, feature, bug fix) and that have a clear
+  scoped. They should be prefixed as indicated below.
 
 1. **Submit a [pull request][link_pullrequest].**<br />
    A member of the development team will review your changes to confirm
@@ -233,7 +236,7 @@ but those accepted fastest will follow a workflow similar to the following:
      * `STY`: style changes ([example][sty_ex])
      * `REF`: refactoring existing code ([example][ref_ex])
      * `CI`: updates to continuous integration infrastructure ([example][ci_ex])
-     * `MAINT`: general maintenance ([example][maint_ex])
+     * `MAINT`/`MNT`: general maintenance ([example][maint_ex])
      * For works-in-progress, add the `WIP` tag in addition to the descriptive prefix.
        Pull-requests tagged with `WIP:` will not be merged until the tag is removed.
 


### PR DESCRIPTION
Accept three-letter prefix for maintenance commits: accept `MNT`:
- Less typing; still readable
- All other prefixes are three-letter prefixes except for `CI`
- There has been a slight shift towards `MNT` lately, e.g. https://github.com/nipreps/fmriprep/blob/f3464b5cd4991042be18d131cbf3ed9c8dd413d9/CHANGES.rst?plain=1#L65; https://github.com/nipreps/smriprep/blob/b839befd008e02f329c59aa634583a18e4049829/CHANGES.rst?plain=1#L31; https://github.com/nipreps/nireports/blob/968d98f7774fafbc745f9d5eb73b40d1e7be4e4c/CHANGES.rst?plain=1#L34; https://github.com/nipreps/sdcflows/blob/b4a01f6e2071a538896e228cba9a43c10b8256cb/CHANGES.rst?plain=1#L34

Take advantage of the commit to specify that commit messages should also be prefixed and that changes in a commit should serve a coherent purpose.