### PR TITLE
MNT: Add GHA workflow file to check links in Markdown files

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,34 @@
+name: Check links
+
+on:
+  push:
+    branches: [mkdocs]
+  pull_request:
+    branches: [mkdocs]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Force to use color
+env:
+  FORCE_COLOR: true
+
+jobs:
+
+  link-check:
+    runs-on: ubuntu-latest
+
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+       - uses: tcort/github-action-markdown-link-check@v1
+         with:
+           use-quiet-mode: yes
+           # use-verbose-mode: no


### PR DESCRIPTION
Add GHA workflow file to check links in Markdown files: signals broken links. Uses the `tcort/github-action-markdown-link-check` action from https://github.com/tcort/github-action-markdown-link-check