### PR TITLE
Add workflow to update telemetry charts automatically

### DIFF
--- a/.github/workflows/update-telemetry.yml
+++ b/.github/workflows/update-telemetry.yml
@@ -1,0 +1,33 @@
+name: Update telemetry charts
+
+on:
+  push:
+    branches: [mkdocs]
+
+jobs:
+  update-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: mkdocs
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Update telemetry images
+        run: |
+          python scripts/update_telemetry_images.py
+      - name: Commit changes
+        run: |
+          git config user.email "nipreps@gmail.com"
+          git config user.name "nipreps-bot"
+          if ! git diff --quiet; then
+            git commit -am "auto: update telemetry charts"
+            git push
+          fi

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,10 @@ We refer to data *directly consumable by analyses* as ***analysis-grade data*** 
 *NiPreps* were conceived as a generalization of *fMRIPrep* across new modalities, populations, cohorts, and species.
 *fMRIPrep* is widely adopted, as our telemetry with Sentry (and now, *in-house* with [migas](https://github.com/nipreps/migas-py)) shows:
 
-| ![fmriprep usage](assets/20250204_weekly.png) |
+| ![fmriprep usage](assets/20250620_weekly.png) |
 |:--:|
 | *fMRIPrep* is executed an average of 11,800 times every week, of which, around 7,800 times it finishes successfully (66.2% success rate). The average number of executions started includes debug and *dry* runs where researchers do not intend actually process data. Therefore, the *effective* (that is, discarding test runs) success ratio of *fMRIPrep* is likely higher. |
 
-| ![fmriprep versions](assets/20250204_versionstream.png) |
+| ![fmriprep versions](assets/20250620_versionstream.png) |
 |:--:|
 | Streamplot of *fMRIPrep*'s version adoption. |

--- a/scripts/update_telemetry_images.py
+++ b/scripts/update_telemetry_images.py
@@ -1,0 +1,56 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2024 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+"""Update references to telemetry charts on the landing page."""
+
+import re
+from pathlib import Path
+
+
+ASSETS_DIR = Path(__file__).parent.parent / "docs" / "assets"
+INDEX_FILE = Path(__file__).parent.parent / "docs" / "index.md"
+
+WEEKLY_RE = re.compile(r"assets/\d{8}_weekly.png")
+VERSIONSTREAM_RE = re.compile(r"assets/\d{8}_versionstream.png")
+
+
+def _latest(pattern: str) -> str | None:
+    files = sorted(ASSETS_DIR.glob(pattern))
+    return files[-1].name if files else None
+
+
+def main(argv=None):  # noqa: D401
+    """Update the links in the index page to the newest telemetry charts."""
+    weekly_file = _latest("*_weekly.png")
+    version_file = _latest("*_versionstream.png")
+
+    if not weekly_file or not version_file:
+        return
+
+    text = INDEX_FILE.read_text()
+    text = WEEKLY_RE.sub(f"assets/{weekly_file}", text)
+    text = VERSIONSTREAM_RE.sub(f"assets/{version_file}", text)
+    INDEX_FILE.write_text(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- automate updating of telemetry chart images in docs
- add GitHub Actions workflow to run the update

## Testing
- `python scripts/update_telemetry_images.py`


------
https://chatgpt.com/codex/tasks/task_e_68557f52a55c8330893b403b49611c4a